### PR TITLE
CFrame Byte Optimization

### DIFF
--- a/src/Miscellaneous/init.luau
+++ b/src/Miscellaneous/init.luau
@@ -11,9 +11,11 @@ local SanitizingEnabled = Settings.sanitize_nanandinf
 
 local FP_EPSILON = 1e-6
 local I16_PRECISION = 32767                 -- int16 range { -32,786, 32,767 }
-local BUFF_CFRAME_SIZE = (3*4) + (1 + 3*2)  -- i.e. 3x f32, 1x u8 and 3x i16
+local BUFF_CFRAME_SIZE_NO_ID = (3*4) + (2*1 + 3*2)  -- i.e. 3x f32, 2x u8 and 3x i16
+local BUFF_CFRAME_SIZE_WITH_ID = (3*4) + 1  -- i.e. 3x f32, 1x u8
 
 local cframe_ToAxisAngle = CFrame.identity.ToAxisAngle
+local cframe_GetComponents = CFrame.identity.GetComponents	
 
 local function getNormalisedQuaternion(cframe: CFrame)
 	local axis_shadowed, angle = cframe_ToAxisAngle(cframe)
@@ -90,18 +92,92 @@ local function decompressQuaternion(index, v0, v1, v2)
 	return v0, v1, v2, d
 end
 
-local function write(buf: buffer, offset: number, input: CFrame)
+--/This is how roblox stores rotations in rbxl binary files, so might as well use it here
+local CFRAME_ROTATION_IDS_WRITE = {
+	["\0\0\128\63\0\0\0\0\0\0\0\0\0\0\0\0\0\0\128\63\0\0\0\0\0\0\0\0\0\0\0\0\0\0\128\63"] = 1,
+	["\0\0\128\63\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\128\191\0\0\0\0\0\0\128\63\0\0\0\0"] = 2,
+	["\0\0\128\63\0\0\0\0\0\0\0\0\0\0\0\0\0\0\128\191\0\0\0\0\0\0\0\0\0\0\0\0\0\0\128\191"] = 3,
+	["\0\0\128\63\0\0\0\0\0\0\0\128\0\0\0\0\0\0\0\0\0\0\128\63\0\0\0\0\0\0\128\191\0\0\0\0"] = 4,
+	["\0\0\0\0\0\0\128\63\0\0\0\0\0\0\128\63\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\128\191"] = 5,
+	["\0\0\0\0\0\0\0\0\0\0\128\63\0\0\128\63\0\0\0\0\0\0\0\0\0\0\0\0\0\0\128\63\0\0\0\0"] = 6,
+	["\0\0\0\0\0\0\128\191\0\0\0\0\0\0\128\63\0\0\0\0\0\0\0\128\0\0\0\0\0\0\0\0\0\0\128\63"] = 7,
+	["\0\0\0\0\0\0\0\0\0\0\128\191\0\0\128\63\0\0\0\0\0\0\0\0\0\0\0\0\0\0\128\191\0\0\0\0"] = 8,
+	["\0\0\0\0\0\0\128\63\0\0\0\0\0\0\0\0\0\0\0\0\0\0\128\63\0\0\128\63\0\0\0\0\0\0\0\0"] = 9,
+	["\0\0\0\0\0\0\0\0\0\0\128\191\0\0\0\0\0\0\128\63\0\0\0\0\0\0\128\63\0\0\0\0\0\0\0\0"] = 10,
+	["\0\0\0\0\0\0\128\191\0\0\0\0\0\0\0\0\0\0\0\0\0\0\128\191\0\0\128\63\0\0\0\0\0\0\0\0"] = 11,
+	["\0\0\0\0\0\0\0\0\0\0\128\63\0\0\0\0\0\0\128\191\0\0\0\0\0\0\128\63\0\0\0\0\0\0\0\128"] = 12,
+	["\0\0\128\191\0\0\0\0\0\0\0\0\0\0\0\0\0\0\128\63\0\0\0\0\0\0\0\0\0\0\0\0\0\0\128\191"] = 13,
+	["\0\0\128\191\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\128\63\0\0\0\0\0\0\128\63\0\0\0\128"] = 14,
+	["\0\0\128\191\0\0\0\0\0\0\0\0\0\0\0\0\0\0\128\191\0\0\0\0\0\0\0\0\0\0\0\0\0\0\128\63"] = 15,
+	["\0\0\128\191\0\0\0\0\0\0\0\128\0\0\0\0\0\0\0\0\0\0\128\191\0\0\0\0\0\0\128\191\0\0\0\128"] = 16,
+	["\0\0\0\0\0\0\128\63\0\0\0\128\0\0\128\191\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\128\63"] = 17,
+	["\0\0\0\0\0\0\0\0\0\0\128\191\0\0\128\191\0\0\0\0\0\0\0\0\0\0\0\0\0\0\128\63\0\0\0\0"] = 18,
+	["\0\0\0\0\0\0\128\191\0\0\0\128\0\0\128\191\0\0\0\0\0\0\0\128\0\0\0\0\0\0\0\0\0\0\128\191"] = 19,
+	["\0\0\0\0\0\0\0\0\0\0\128\63\0\0\128\191\0\0\0\0\0\0\0\0\0\0\0\0\0\0\128\191\0\0\0\0"] = 20,
+	["\0\0\0\0\0\0\128\63\0\0\0\0\0\0\0\0\0\0\0\0\0\0\128\191\0\0\128\191\0\0\0\0\0\0\0\0"] = 21,
+	["\0\0\0\0\0\0\0\0\0\0\128\63\0\0\0\0\0\0\128\63\0\0\0\128\0\0\128\191\0\0\0\0\0\0\0\0"] = 22,
+	["\0\0\0\0\0\0\128\191\0\0\0\0\0\0\0\0\0\0\0\0\0\0\128\63\0\0\128\191\0\0\0\0\0\0\0\0"] = 23,
+	["\0\0\0\0\0\0\0\0\0\0\128\191\0\0\0\0\0\0\128\191\0\0\0\128\0\0\128\191\0\0\0\0\0\0\0\128"] = 24,
+}
+
+local CFRAME_ROTATION_IDS_READ = {
+	"\0\0\128\63\0\0\0\0\0\0\0\0\0\0\0\0\0\0\128\63\0\0\0\0\0\0\0\0\0\0\0\0\0\0\128\63",
+	"\0\0\128\63\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\128\191\0\0\0\0\0\0\128\63\0\0\0\0",
+	"\0\0\128\63\0\0\0\0\0\0\0\0\0\0\0\0\0\0\128\191\0\0\0\0\0\0\0\0\0\0\0\0\0\0\128\191",
+	"\0\0\128\63\0\0\0\0\0\0\0\128\0\0\0\0\0\0\0\0\0\0\128\63\0\0\0\0\0\0\128\191\0\0\0\0",
+	"\0\0\0\0\0\0\128\63\0\0\0\0\0\0\128\63\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\128\191",
+	"\0\0\0\0\0\0\0\0\0\0\128\63\0\0\128\63\0\0\0\0\0\0\0\0\0\0\0\0\0\0\128\63\0\0\0\0",
+	"\0\0\0\0\0\0\128\191\0\0\0\0\0\0\128\63\0\0\0\0\0\0\0\128\0\0\0\0\0\0\0\0\0\0\128\63",
+	"\0\0\0\0\0\0\0\0\0\0\128\191\0\0\128\63\0\0\0\0\0\0\0\0\0\0\0\0\0\0\128\191\0\0\0\0",
+	"\0\0\0\0\0\0\128\63\0\0\0\0\0\0\0\0\0\0\0\0\0\0\128\63\0\0\128\63\0\0\0\0\0\0\0\0",
+	"\0\0\0\0\0\0\0\0\0\0\128\191\0\0\0\0\0\0\128\63\0\0\0\0\0\0\128\63\0\0\0\0\0\0\0\0",
+	"\0\0\0\0\0\0\128\191\0\0\0\0\0\0\0\0\0\0\0\0\0\0\128\191\0\0\128\63\0\0\0\0\0\0\0\0",
+	"\0\0\0\0\0\0\0\0\0\0\128\63\0\0\0\0\0\0\128\191\0\0\0\0\0\0\128\63\0\0\0\0\0\0\0\128",
+	"\0\0\128\191\0\0\0\0\0\0\0\0\0\0\0\0\0\0\128\63\0\0\0\0\0\0\0\0\0\0\0\0\0\0\128\191",
+	"\0\0\128\191\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\128\63\0\0\0\0\0\0\128\63\0\0\0\128",
+	"\0\0\128\191\0\0\0\0\0\0\0\0\0\0\0\0\0\0\128\191\0\0\0\0\0\0\0\0\0\0\0\0\0\0\128\63",
+	"\0\0\128\191\0\0\0\0\0\0\0\128\0\0\0\0\0\0\0\0\0\0\128\191\0\0\0\0\0\0\128\191\0\0\0\128",
+	"\0\0\0\0\0\0\128\63\0\0\0\128\0\0\128\191\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\128\63",
+	"\0\0\0\0\0\0\0\0\0\0\128\191\0\0\128\191\0\0\0\0\0\0\0\0\0\0\0\0\0\0\128\63\0\0\0\0",
+	"\0\0\0\0\0\0\128\191\0\0\0\128\0\0\128\191\0\0\0\0\0\0\0\128\0\0\0\0\0\0\0\0\0\0\128\191",
+	"\0\0\0\0\0\0\0\0\0\0\128\63\0\0\128\191\0\0\0\0\0\0\0\0\0\0\0\0\0\0\128\191\0\0\0\0",
+	"\0\0\0\0\0\0\128\63\0\0\0\0\0\0\0\0\0\0\0\0\0\0\128\191\0\0\128\191\0\0\0\0\0\0\0\0",
+	"\0\0\0\0\0\0\0\0\0\0\128\63\0\0\0\0\0\0\128\63\0\0\0\128\0\0\128\191\0\0\0\0\0\0\0\0",
+	"\0\0\0\0\0\0\128\191\0\0\0\0\0\0\0\0\0\0\0\0\0\0\128\63\0\0\128\191\0\0\0\0\0\0\0\0",
+	"\0\0\0\0\0\0\0\0\0\0\128\191\0\0\0\0\0\0\128\191\0\0\0\128\0\0\128\191\0\0\0\0\0\0\0\128",
+}
+
+--/Gets the rotationID of a cframe if it can be compressed
+local function canCompressCFrame(cframe: CFrame)
+	local _,_,_ ,r00,r01,r02,r10,r11,r12,r20,r21,r22 = cframe_GetComponents(cframe)
+	local rotationID = CFRAME_ROTATION_IDS_WRITE[string.pack("<fffffffff", r00, r01, r02, r10, r11, r12, r20, r21, r22)]
+	return rotationID ~= nil, rotationID
+end
+
+local function write(buf: buffer, offset: number, input: CFrame, rotationID: number?)
+
+	--/Split the cframe into its components
 	local pos = input.Position
 
 	buffer.writef32(buf, offset, pos.X)
 	buffer.writef32(buf, offset + 4, pos.Y)
 	buffer.writef32(buf, offset + 8, pos.Z)
 
-	local qi, q0, q1, q2 = compressQuaternion(input)
-	buffer.writeu8(buf, offset + 12, qi)
-	buffer.writei16(buf, offset + 13, q0)
-	buffer.writei16(buf, offset + 15, q1)
-	buffer.writei16(buf, offset + 17, q2)
+	--/This is how roblox stores rotations in rbxl binary files, so might as well use it here (if it's not in the table we only gain 1 byte compared to previous implementation)
+	if rotationID then
+		--/WAHOO! We can use the rotationID to skip the quaternion compression (aka skipping 3x i16 and 1x u8 [7 bytes])
+		buffer.writeu8(buf, offset + 12, rotationID)
+	else
+		--/If it's not in the table, we need to write a quaternion instead
+		buffer.writeu8(buf, offset + 12, 0)
+		
+		--/Compress the rotation into a quaternion
+		local qi, q0, q1, q2 = compressQuaternion(input)
+		buffer.writeu8(buf, offset + 13, qi)
+		buffer.writei16(buf, offset + 14, q0)
+		buffer.writei16(buf, offset + 16, q1)
+		buffer.writei16(buf, offset + 18, q2)
+	end
 end
 
 local function read(buf: buffer, byte: number, offset: number): (CFrame, number)
@@ -115,20 +191,38 @@ local function read(buf: buffer, byte: number, offset: number): (CFrame, number)
 		if (z / z) ~= 1 then z = 0 end
 	end
 
-	local qi = buffer.readu8(buf, offset + 12)
-	local q0 = buffer.readi16(buf, offset + 13)
-	local q1 = buffer.readi16(buf, offset + 15)
-	local q2 = buffer.readi16(buf, offset + 17)
+	--/Read the rotationID
+	local rotationID = buffer.readu8(buf, offset + 12)
+	if rotationID == 0 then
+		--/We need to read a quaternion since it's not in the table
+		local qi = buffer.readu8(buf, offset + 13)
+		local q0 = buffer.readi16(buf, offset + 14)
+		local q1 = buffer.readi16(buf, offset + 16)
+		local q2 = buffer.readi16(buf, offset + 18)
 
-	local qx, qy, qz, qw = decompressQuaternion(qi, q0, q1, q2)
-	return CFrame.new(x, y, z, qx, qy, qz, qw), offset + BUFF_CFRAME_SIZE
+		local qx, qy, qz, qw = decompressQuaternion(qi, q0, q1, q2)
+		return CFrame.new(x, y, z, qx, qy, qz, qw), offset + BUFF_CFRAME_SIZE_NO_ID
+	end
+
+	--/Failed to read rotationID, this is a fallback so it doesnt error but it should never happen unless its either corrupted or not a cframe
+	local rotation = CFRAME_ROTATION_IDS_READ[rotationID]
+	if not rotation then
+		return CFrame.new(x, y, z), offset + BUFF_CFRAME_SIZE_WITH_ID
+	end
+
+	--/Unpack rotation (free 7 bytes compared to previous implementation :D)
+	local r00, r01, r02, r10, r11, r12, r20, r21, r22 = string.unpack("<fffffffff", rotation)
+	return CFrame.new(x, y, z, r00, r01, r02, r10, r11, r12, r20, r21, r22), offset + BUFF_CFRAME_SIZE_WITH_ID
+
 end
 
 return {
 	readCFrame = read,
 	writeCFrame = write,
+	canCompressCFrame = canCompressCFrame,
 
-	cframesize = BUFF_CFRAME_SIZE,
+	cframesize_no_id = BUFF_CFRAME_SIZE_NO_ID,
+	cframesize_with_id = BUFF_CFRAME_SIZE_WITH_ID,
 	
 	writef16 = floatencoder.writef16;
 	readf16 = floatencoder.readf16;

--- a/src/Write.luau
+++ b/src/Write.luau
@@ -74,7 +74,9 @@ local fullrbxenum: boolean = Settings.rbxenum_behavior == 'full'
 
 local writef16 = Miscellaneous.writef16
 local writeCFrame = Miscellaneous.writeCFrame
-local CFrameSize = Miscellaneous.cframesize
+local canCompressCFrame = Miscellaneous.canCompressCFrame
+local CFrameSizeNoID = Miscellaneous.cframesize_no_id
+local CFrameSizeWithID = Miscellaneous.cframesize_with_id
 
 -- shift the byte associated with a value/datatype by the number given
 local tryshift = function(v: number, shiftseed: number?): number
@@ -367,10 +369,13 @@ local function write(
 					buffer.writef32(buff, cursor, value.Y); cursor += 4
 				elseif t == "CFrame" then
 					local value: CFrame = value
-					buff = expandbuffertosize(buff, cursor + CFrameSize + 1, info)
+					local canCompress, rotationID = canCompressCFrame(value)
+
+					local size = (canCompress and CFrameSizeWithID or CFrameSizeNoID) + 1
+					buff = expandbuffertosize(buff, cursor + size, info)
 
 					writebytesign(buff, cursor, 17, isdict, shiftseed); cursor += 1
-					writeCFrame(buff, cursor, value); cursor += CFrameSize
+					writeCFrame(buff, cursor, value, rotationID); cursor += size
 				elseif t == "Ray" then
 					local value: Ray = value
 					buff = expandbuffertosize(buff, cursor + 25, info)


### PR DESCRIPTION
Save up to 5 bytes per CFrame with this optimization. Roblox internally uses these same values when creating a rbxl binary. Stores a table of common rotations and stores in a list then sends only one byte instead of the quaternion when it hits. Only problem is if it misses it adds an extra byte.